### PR TITLE
icon themes: add mate to inherits in index.theme file

### DIFF
--- a/usr/share/icons/Ambiant-MATE/index.theme
+++ b/usr/share/icons/Ambiant-MATE/index.theme
@@ -1,7 +1,7 @@
 [Icon Theme]
 Name=Ambiant-MATE
 Comment=Smooth modern theme designed to be intuitive.
-Inherits=ubuntu-mono-dark,Humanity-Dark,gnome,hicolor
+Inherits=ubuntu-mono-dark,Humanity-Dark,gnome,hicolor,mate
 
 Example=directory-x-normal
 

--- a/usr/share/icons/Radiant-MATE/index.theme
+++ b/usr/share/icons/Radiant-MATE/index.theme
@@ -1,7 +1,7 @@
 [Icon Theme]
 Name=Radiant-MATE
 Comment=Smooth modern theme designed to be intuitive.
-Inherits=ubuntu-mono-light,Humanity,gnome,hicolor
+Inherits=ubuntu-mono-light,Humanity,gnome,hicolor,mate
 
 Example=directory-x-normal
 


### PR DESCRIPTION
This will displays flags from mate-icon-theme-1.18.2/16.2 with keyboard na-tray applet.
1. install latest mate-icon-theme
2. apply the commit
3. set
```
[rave@mother ~]$ gsettings get org.mate.peripherals-keyboard-xkb.indicator show-flags
true
```